### PR TITLE
auto docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         # won't work without a nojekyll file
         run: |
           jupyter-book build .
-          touch build/.nojekyll
+          touch _build/html/.nojekyll
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,5 +33,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.AccessToken }}
-          BRANCH: docs # The branch the action should deploy to.
+          BRANCH: docs_test # The branch the action should deploy to.
           FOLDER: _build/html # The folder the action should deploy.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - master
+      - docs
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies 🔨
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build 🔧
+        # won't work without a nojekyll file
+        run: |
+          jupyter-book build .
+          touch build/.nojekyll
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.AccessToken }}
+          BRANCH: docs # The branch the action should deploy to.
+          FOLDER: _build/html # The folder the action should deploy.


### PR DESCRIPTION
The current implementation builds when a change happens on branches master or docs, and pushes the changes to branch `docs_test`. The build fails because @simonvh should add a github access token as a secret to the repo (https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)

todo/change:
- access token
- only build on master
- push to gh-pages